### PR TITLE
FEAT: repo domain db 저장.. 추가 기능 구현 등..

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/AccessTokenController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/AccessTokenController.java
@@ -1,30 +1,20 @@
 package com.Teletubbies.Apollo.auth.controller;
 
-import com.Teletubbies.Apollo.auth.domain.User;
 import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
-import com.Teletubbies.Apollo.auth.dto.RepoInfoResponse;
-import com.Teletubbies.Apollo.auth.repository.UserRepository;
 import com.Teletubbies.Apollo.auth.service.OAuthService;
 import com.Teletubbies.Apollo.auth.service.UserService;
-import org.json.simple.parser.ParseException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 public class AccessTokenController {
     private final OAuthService oAuthService;
     private final UserService userService;
-    private final UserRepository userRepository;
-
-    public AccessTokenController(OAuthService oAuthService, UserService userService,
-                                 UserRepository userRepository) {
+    public AccessTokenController(OAuthService oAuthService, UserService userService) {
         this.oAuthService = oAuthService;
         this.userService = userService;
-        this.userRepository = userRepository;
     }
 
     @GetMapping("/repository")
@@ -33,11 +23,5 @@ public class AccessTokenController {
         MemberInfoResponse memberInfoResponse = oAuthService.getUserInfo(accessToken).getBody();
         userService.saveUser(memberInfoResponse);
         return ResponseEntity.ok("success");
-    }
-    @GetMapping("/repository/list")
-    public String getRepoList() throws ParseException {
-        User user = userRepository.findByLogin("dlawjddn").get();
-        List<RepoInfoResponse> repoURL = oAuthService.getRepoURL(user);
-        return "repo list success";
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/RepoController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/RepoController.java
@@ -1,0 +1,22 @@
+package com.Teletubbies.Apollo.auth.controller;
+
+import com.Teletubbies.Apollo.auth.domain.User;
+import com.Teletubbies.Apollo.auth.repository.UserRepository;
+import com.Teletubbies.Apollo.auth.service.RepoService;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RepoController {
+    private final UserRepository userRepository;
+    private final RepoService repoService;
+    @GetMapping("/repository/list")
+    public String saveRepoList() throws ParseException {
+        User user = userRepository.findByLogin("dlawjddn").get();
+        repoService.saveRepo(user);
+        return "repo list success";
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/auth/domain/Repo.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/domain/Repo.java
@@ -1,13 +1,12 @@
 package com.Teletubbies.Apollo.auth.domain;
 
 import com.Teletubbies.Apollo.auth.dto.RepoInfoResponse;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class Repo {
     @Id
@@ -15,7 +14,9 @@ public class Repo {
     private Long id;
     private String repoName;
     private String repoUrl;
+    private String ownerLogin;
     public Repo(RepoInfoResponse response){
+        this.ownerLogin = response.getUserLogin();
         this.repoName = response.getRepoName();
         this.repoUrl = response.getRepoURL();
     }

--- a/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RepoInfoResponse {
+    private String userLogin;
     @JsonProperty("name")
     private String repoName;
     @JsonProperty("html_url")

--- a/src/main/java/com/Teletubbies/Apollo/auth/service/OAuthService.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/service/OAuthService.java
@@ -1,15 +1,9 @@
 package com.Teletubbies.Apollo.auth.service;
 
-import com.Teletubbies.Apollo.auth.domain.User;
 import com.Teletubbies.Apollo.auth.dto.AccessTokenRequest;
 import com.Teletubbies.Apollo.auth.dto.AccessTokenResponse;
 import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
-import com.Teletubbies.Apollo.auth.dto.RepoInfoResponse;
 import lombok.RequiredArgsConstructor;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -18,15 +12,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class OAuthService {
     private static final String ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
     private static final String MEMBER_INFO_URL = "https://api.github.com/user";
-    private static final String REPO_LIST_URL = "https://api.github.com/users";
     private static final RestTemplate restTemplate = new RestTemplate();
 
     @Value("${security.oauth.github.client-id}")
@@ -52,30 +43,5 @@ public class OAuthService {
                 request,
                 MemberInfoResponse.class
         );
-    }
-    public List<RepoInfoResponse> getRepoURL(User user) throws ParseException {
-        // resource server에 레포 정보 http 요청
-        HttpHeaders headers = new HttpHeaders();
-        HttpEntity<Void> request = new HttpEntity<>(headers);
-        ResponseEntity<String> jsonData = restTemplate.exchange(
-                REPO_LIST_URL + "/" + user.getLogin() + "/repos",
-                HttpMethod.GET,
-                request,
-                String.class
-        );
-        // json 정보를 바탕으로 parsing
-        List<RepoInfoResponse> repoInfo = new ArrayList<>();
-        JSONParser jsonParser = new JSONParser();
-        JSONArray jsonArray = (JSONArray) jsonParser.parse(jsonData.getBody());
-
-        // json에서 추출한 정보를 바탕으로 dto list 생성
-        for (int i=0; i< jsonArray.size(); i++){
-            JSONObject jsonDataObject = (JSONObject) jsonArray.get(i);
-            repoInfo.add(new RepoInfoResponse(
-                    jsonDataObject.get("name").toString(),
-                    jsonDataObject.get("html_url").toString())
-            );
-        }
-        return repoInfo;
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/auth/service/RepoService.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/service/RepoService.java
@@ -1,0 +1,58 @@
+package com.Teletubbies.Apollo.auth.service;
+
+import com.Teletubbies.Apollo.auth.domain.User;
+import com.Teletubbies.Apollo.auth.dto.RepoInfoResponse;
+import com.Teletubbies.Apollo.auth.repository.RepoRepository;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+@Service
+@RequiredArgsConstructor
+public class RepoService {
+    private final RepoRepository repoRepository;
+    private static String REPO_LIST_URL = "https://api.github.com/users";
+    private static RestTemplate restTemplate = new RestTemplate();
+    public List<RepoInfoResponse> getRepoURL(User user) throws ParseException {
+        // resource server에 레포 정보 http 요청
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<String> jsonData = restTemplate.exchange(
+                REPO_LIST_URL + "/" + user.getLogin() + "/repos",
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+        // json 정보를 바탕으로 parsing
+        List<RepoInfoResponse> repoInfo = new ArrayList<>();
+        JSONParser jsonParser = new JSONParser();
+        JSONArray jsonArray = (JSONArray) jsonParser.parse(jsonData.getBody());
+
+        // json에서 추출한 정보를 바탕으로 dto list 생성
+        for (int i=0; i< jsonArray.size(); i++){
+            JSONObject jsonDataObject = (JSONObject) jsonArray.get(i);
+            repoInfo.add(new RepoInfoResponse(
+                    user.getLogin(),
+                    jsonDataObject.get("name").toString(),
+                    jsonDataObject.get("html_url").toString())
+            );
+        }
+        return repoInfo;
+    }
+    public void saveRepo(User user) throws ParseException {
+        List<RepoInfoResponse> repoInfos = getRepoURL(user);
+        for (RepoInfoResponse response : repoInfos) {
+            repoRepository.save(response.changeDTOtoObj(response));
+        }
+    }
+}


### PR DESCRIPTION
- 일단 너무 집중해서 깃 커밋을 못 함.. 다음부턴 더 유의하겠음;;
- 바꾼 부분 순서화해서 정리
- 1. repo 정보를 받아오는 과정이 access_token이 필요한 줄 알아서 OAuthService에 구현했는데, 이를 수정해서 RepoService에 옮겼음 (리팩토링)
- 2. repo repository 생성
- 3. repo controller 생성
- 4. repo dto (repoInfoResponse) userLogin 필드 추가 -> repository 객체에서 user가 누구인지 쉽게 파악하기 위해서
- 5. repo 객체 db와 연결 및 저장 성공