### PR TITLE
FEAT: jwt 사용 위해서 UserDetail 인터페이스 상속 추가

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/domain/User.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/domain/User.java
@@ -2,23 +2,35 @@ package com.Teletubbies.Apollo.auth.domain;
 
 import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Entity
 @NoArgsConstructor
 @Table(name="user")
 @Getter
-public class User {
+public class User implements UserDetails {
 
     @Id
     private Long id;
-    private String login;
+    private String login; // username에 해당하는 부분
     private String name;
     private String profileUrl;
     @Column(nullable=true)
-    private String email;
+    private String email; // userPassword에 해당하는 부분
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private List<String> roles = new ArrayList<>();
 
     public User (MemberInfoResponse memberInfoResponse) {
         this.id = memberInfoResponse.getOauthId();
@@ -26,5 +38,41 @@ public class User {
         this.name = memberInfoResponse.getUsername();
         this.email = memberInfoResponse.getEmail();
         this.profileUrl = memberInfoResponse.getProfileUrl();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return this.roles.stream()
+                .map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return this.email;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.login;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 }


### PR DESCRIPTION
- jwt 사용을 위해서 UserDetail interface 상속
- 상속 후 내장함수 오버라이딩까지
- 우리 아이디는 userLogin 그대로 가져가고
- password는 아이디로 하려고 했는데 String 반환이라 일단 이메일로 했음
- password 같은 경우에는 이메일이 좀 그러면 Long을 String으로 변환해서 넘겨도 될 듯, 추후 논의 사항