### PR TITLE
FEAT: 회원가입 로직 분리

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/AccessTokenController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/AccessTokenController.java
@@ -13,15 +13,13 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class AccessTokenController {
     private final OAuthService oAuthService;
-    private final UserService userService;
     @PostMapping("/authenticate")
-    public ResponseEntity<String> getUserInfo(@RequestParam String code) {
+    public MemberInfoResponse getUserInfo(@RequestParam String code) {
         String accessToken = oAuthService.getAccessToken(code);
         log.info("access-token 발행 성공");
         MemberInfoResponse memberInfoResponse = oAuthService.getUserInfo(accessToken).getBody();
         log.info("유저 정보 객체 dto 변환 성공");
-        userService.saveUser(memberInfoResponse);
-        log.info("유저 정보 저장 성공");
-        return ResponseEntity.ok("success");
+
+        return memberInfoResponse;
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
@@ -1,18 +1,23 @@
 package com.Teletubbies.Apollo.auth.controller;
 
 import com.Teletubbies.Apollo.auth.domain.User;
+import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
 import com.Teletubbies.Apollo.auth.service.UserService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+@Slf4j
 @RestController
 @RequestMapping("/api")
 public class UserController {
     private final UserService userService;
     public UserController(UserService userService){
         this.userService = userService;
+    }
+    @PostMapping("save/user")
+    public String saveUser(@RequestBody MemberInfoResponse memberInfoResponse){
+        Long savedUserId = userService.saveUser(memberInfoResponse);
+        log.info("유저 저장 완료");
+        return savedUserId.toString();
     }
     @GetMapping("/login/find/{userId}")
     public String findUserById(@PathVariable Long userId){

--- a/src/main/java/com/Teletubbies/Apollo/auth/service/UserService.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/service/UserService.java
@@ -19,11 +19,12 @@ import static com.Teletubbies.Apollo.core.exception.CustomErrorCode.NOT_FOUND_US
 public class UserService {
     private final UserRepository userRepository;
     @Transactional
-    public void saveUser(MemberInfoResponse memberInfoResponse) {
+    public Long saveUser(MemberInfoResponse memberInfoResponse) {
         User userToSave = memberInfoResponse.changeDTOtoObj(memberInfoResponse);
         if (userRepository.existsById(userToSave.getId()))
             throw new ApolloException(DUPLICATED_USER_ERROR, "이미 존재하는 회원입니다");
-        userRepository.save(memberInfoResponse.changeDTOtoObj(memberInfoResponse));
+        User savedUser = userRepository.save(memberInfoResponse.changeDTOtoObj(memberInfoResponse));
+        return savedUser.getId();
     }
     public User getUserById(Long id){
         Optional<User> optionalUser = userRepository.findById(id);


### PR DESCRIPTION
- 기존 로직: github 인증 받고 바로 회원 저장까지 해버렸음
- 변경 로직: github 인증 받고 유저 정보를 갖고 있는 객체를 넘겨서 임시적으로 작동을 멈추고, 이후 추가적인 요청에 의해 회원저장 하도록 함
