### PR TITLE
FEAT: 유저 토큰을 생성할 때 쿼리문을 작성해야하는 과정을 줄임

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
@@ -3,6 +3,9 @@ package com.Teletubbies.Apollo.auth.controller;
 import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
 import com.Teletubbies.Apollo.auth.service.UserService;
+import com.Teletubbies.Apollo.jwt.repository.ApolloUserTokenRepository;
+import com.Teletubbies.Apollo.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 @Slf4j
@@ -10,14 +13,18 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 public class UserController {
     private final UserService userService;
-    public UserController(UserService userService){
+    private final JwtService jwtService;
+    public UserController(UserService userService, JwtService jwtService){
         this.userService = userService;
+        this.jwtService = jwtService;
     }
     @PostMapping("/save/user")
     public String saveUser(@RequestBody MemberInfoResponse memberInfoResponse){
-        Long savedUserId = userService.saveUser(memberInfoResponse);
+        ApolloUser savedUser = userService.saveUser(memberInfoResponse);
         log.info("유저 저장 완료");
-        return savedUserId.toString();
+        jwtService.saveToken(savedUser.getLogin(), savedUser.getId().toString());
+        log.info("Token 기초 정보 저장 완료");
+        return "ok";
     }
     @GetMapping("/login/find/{userId}")
     public String findUserById(@PathVariable Long userId){

--- a/src/main/java/com/Teletubbies/Apollo/auth/service/UserService.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/service/UserService.java
@@ -20,12 +20,12 @@ import static com.Teletubbies.Apollo.core.exception.CustomErrorCode.NOT_FOUND_US
 public class UserService {
     private final UserRepository userRepository;
     @Transactional
-    public Long saveUser(MemberInfoResponse memberInfoResponse) {
+    public ApolloUser saveUser(MemberInfoResponse memberInfoResponse) {
         ApolloUser apolloUserToSave = memberInfoResponse.changeDTOtoObj(memberInfoResponse);
         if (userRepository.existsById(apolloUserToSave.getId()))
             throw new ApolloException(DUPLICATED_USER_ERROR, "이미 존재하는 회원입니다");
         ApolloUser savedApolloUser = userRepository.save(memberInfoResponse.changeDTOtoObj(memberInfoResponse));
-        return savedApolloUser.getId();
+        return savedApolloUser;
     }
     public ApolloUser getUserById(Long id){
         Optional<ApolloUser> optionalUser = userRepository.findById(id);

--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
@@ -29,6 +29,10 @@ public class ApolloUserToken implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
+    public ApolloUserToken(String userLogin, String userId){
+        this.userLogin = userLogin;
+        this.userId = userId;
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/ApolloUserDetailsService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/ApolloUserDetailsService.java
@@ -1,5 +1,7 @@
 package com.Teletubbies.Apollo.jwt.service;
 
+import com.Teletubbies.Apollo.auth.domain.ApolloUser;
+import com.Teletubbies.Apollo.auth.repository.UserRepository;
 import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
 import com.Teletubbies.Apollo.jwt.repository.ApolloUserTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,27 +13,45 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApolloUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
     private final ApolloUserTokenRepository apolloUserTokenRepository;
     private final PasswordEncoder passwordEncoder;
     @Override
     public UserDetails loadUserByUsername(String userLogin) throws UsernameNotFoundException {
         log.info("ApolloUserDeatailService 진입 성공");
+        /*
+        Optional<ApolloUser> findUser = userRepository.findByLogin(userLogin);
+        log.info("find-user login: " + findUser.get().getId());
+        log.info("find-user login: " + findUser.get().getLogin());
+        ApolloUserToken apolloUserToken = changeTokenToUser(findUser);
+
+         */
+
         Optional<ApolloUserToken> findUser = apolloUserTokenRepository.findByUserLogin(userLogin);
-        log.info("find-user login: ", findUser.get().getUserLogin());
+
+        //return Optional.ofNullable(apolloUserToken).map(this::createUserDetail).orElseThrow();
+
         return apolloUserTokenRepository.findByUserLogin(userLogin)
                 .map(this::createUserDetail)
                 .orElseThrow();
+
     }
     public UserDetails createUserDetail(ApolloUserToken apolloUserToken){
         return User.builder()
                 .username(apolloUserToken.getUsername())
                 .password(passwordEncoder.encode(apolloUserToken.getPassword()))
                 .build();
+    }
+    public ApolloUserToken changeTokenToUser (Optional<ApolloUser> apolloUser){
+        if (apolloUser != null && apolloUser.isPresent()){
+            return new ApolloUserToken(apolloUser.get().getLogin(), apolloUser.get().getId().toString());
+        } else throw new IllegalArgumentException("유저 정보가 없습니다");
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
@@ -1,7 +1,10 @@
 package com.Teletubbies.Apollo.jwt.service;
 
+import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.jwt.JwtTokenProvider;
+import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
 import com.Teletubbies.Apollo.jwt.dto.TokenInfo;
+import com.Teletubbies.Apollo.jwt.repository.ApolloUserTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,8 +16,12 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class JwtService {
+    private final ApolloUserTokenRepository apolloUserTokenRepository;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
+    public void saveToken(String userLogin, String userId){
+        apolloUserTokenRepository.save(new ApolloUserToken(userLogin, userId));
+    }
     public TokenInfo login(String userLogin, String userId){
         // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
         // 이때 authentication 는 인증 여부를 확인하는 authenticated 값이 false
@@ -27,7 +34,7 @@ public class JwtService {
         // getDetail = null, getAuthentirities = 없음
 
         // 2. 실제 검증 (사용자 비밀번호 체크)이 이루어지는 부분
-        // authenticate 매서드가 실행될 때 CustomUserDetailsService 에서 만든 loadUserByUsername 메서드가 실행
+        // authenticate 매서드가 실행될 때 ApolloUserDetailsService 에서 만든 loadUserByUsername 메서드가 실행
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
         log.info("실제 검증 성공");
 


### PR DESCRIPTION
- jwt token 생성시에 이를 테스트 하기 위해서 쿼리문으로 저장을 하고 postman으로 했어야했는데
- 유저 정보를 받아와서 저장하는 로직에 jwt token을 생성할 때 필요한 UserDetail 객체 저장까지 함
- 이제 그냥 프론트 단에서 저장하고 바로 postman으로 쏴주기 가능
- 일단 지금 커밋해두고 정리한 뒤, 너가 말했던 리퀘스트 매핑도 추가해서 곧 추가 커밋 예정