### PR TITLE
Feat: 클라이언트에게 레포 정보 전달 로직 구현

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/RepoController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/RepoController.java
@@ -2,6 +2,7 @@ package com.Teletubbies.Apollo.auth.controller;
 
 import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.auth.domain.Repo;
+import com.Teletubbies.Apollo.auth.dto.RepoInfoJsonResponse;
 import com.Teletubbies.Apollo.auth.service.RepoService;
 import com.Teletubbies.Apollo.auth.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -21,10 +24,10 @@ public class RepoController {
     private final RepoService repoService;
 
     @GetMapping("/repository/list/{userLogin}")
-    public String saveRepoList(@PathVariable String userLogin) throws ParseException {
+    public List<RepoInfoJsonResponse> saveRepoList(@PathVariable String userLogin) throws ParseException {
         ApolloUser findApolloUser = userService.getUserByLogin(userLogin);
-        repoService.saveRepo(findApolloUser);
-        return "repo list success";
+        List<RepoInfoJsonResponse> repoInfoJsonResponses = repoService.saveRepo(findApolloUser);
+        return repoInfoJsonResponses;
     }
     @GetMapping("/repository/find/login/{userLogin}")
     public String findByLogin(@PathVariable String userLogin){

--- a/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoJsonResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoJsonResponse.java
@@ -1,0 +1,10 @@
+package com.Teletubbies.Apollo.auth.dto;
+
+import lombok.Data;
+
+@Data
+public class RepoInfoJsonResponse {
+    private String userLogin;
+    private String repoName;
+    private String repoUrl;
+}

--- a/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/dto/RepoInfoResponse.java
@@ -20,4 +20,11 @@ public class RepoInfoResponse {
     public Repo changeDTOtoObj(RepoInfoResponse response){
         return new Repo(response);
     }
+    public RepoInfoJsonResponse changeObjToJSON(RepoInfoResponse response){
+        RepoInfoJsonResponse repoInfoJsonResponse = new RepoInfoJsonResponse();
+        repoInfoJsonResponse.setUserLogin(response.getUserLogin());
+        repoInfoJsonResponse.setRepoName(response.getRepoName());
+        repoInfoJsonResponse.setRepoUrl(response.getRepoURL());
+        return repoInfoJsonResponse;
+    }
 }

--- a/src/main/java/com/Teletubbies/Apollo/auth/service/RepoService.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/service/RepoService.java
@@ -2,6 +2,7 @@ package com.Teletubbies.Apollo.auth.service;
 
 import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.auth.domain.Repo;
+import com.Teletubbies.Apollo.auth.dto.RepoInfoJsonResponse;
 import com.Teletubbies.Apollo.auth.dto.RepoInfoResponse;
 import com.Teletubbies.Apollo.auth.repository.RepoRepository;
 import com.Teletubbies.Apollo.core.exception.ApolloException;
@@ -59,13 +60,24 @@ public class RepoService {
         return repoInfo;
     }
     @Transactional
-    public void saveRepo(ApolloUser apolloUser) throws ParseException {
+    public List<RepoInfoJsonResponse> saveRepo(ApolloUser apolloUser) throws ParseException {
+        List<RepoInfoJsonResponse> repoInfoJson= new ArrayList<>(); // JSON 용 리스트 생성
+
         List<RepoInfoResponse> repoInfos = getRepoURL(apolloUser);
         log.info("get repo list ok");
+
+        for (RepoInfoResponse repoInfo : repoInfos) {
+            repoInfoJson.add(repoInfo.changeObjToJSON(repoInfo));
+        }
+        log.info("클라이언트에 보낼 리스트 생성 완료");
+
         for (RepoInfoResponse response : repoInfos) {
             if (repoRepository.existsById(response.getId())) continue;
             repoRepository.save(response.changeDTOtoObj(response));
         }
+        log.info("레포지토리 중복 검사 완료");
+
+        return repoInfoJson; //  클라이언트에 보낼 리스트 반환
     }
     @Transactional(readOnly = true)
     public List<Repo> findByLogin(ApolloUser apolloUser){


### PR DESCRIPTION
- 클라이언트에게 사용자 아이디, 레포 이름, 레포 url 전달하기 위한 로직 구현
- 요청이 들어오면 DB 저장과 클라이언트 전달 수행
- DB 저장 DTO는 repository에 해당하는 ID값이 있고, 클라이언트 전달 DTO는 repoID가 존재하지 않음 그래서 일단 DTO 새로 생성해서 전달
- *** 그래서 DTO 이름 재정의 필요함 *** -> 현재 좀 애매하게 되어있음
- 뿐만 아니라 로직 자체도 그렇게 깨끗한 느낌은 아니라 좀 더 고민해봐야하는 부분인 듯 (DTO를 더 깔끔하게 정의하면 될 듯 함)