### PR TITLE
Fix: jwt 권한 정보 수정

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
@@ -1,73 +1,32 @@
 package com.Teletubbies.Apollo.jwt.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
+import lombok.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-public class ApolloUserToken implements UserDetails {
+public class ApolloUserToken{
     @Id
-    @Column(updatable = false, unique = true, nullable = false)
+    @Column(name = "user_for_token_id", updatable = false, unique = true, nullable = false)
     private String userLogin;
     @Column(nullable = false)
     private String userId;
+    private boolean activated;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Builder.Default
-    private List<String> roles = new ArrayList<>();
+    @ManyToMany
+    @JoinTable(
+            name = "user_authority",
+            joinColumns = {@JoinColumn(name = "user_for_token_id", referencedColumnName = "user_for_token_id")},
+            inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
+    private Set<Authority> authorities;
     public ApolloUserToken(String userLogin, String userId){
         this.userLogin = userLogin;
         this.userId = userId;
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return this.roles.stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-    }
-
-    @Override
-    public String getPassword() {
-        return this.userId;
-    }
-
-    @Override
-    public String getUsername() {
-        return this.userLogin;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
+        this.activated = true;
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/Authority.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/Authority.java
@@ -1,0 +1,20 @@
+package com.Teletubbies.Apollo.jwt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "authorities")
+public class Authority {
+    @Id
+    @Column(name = "authority_name")
+    private String authorityName;
+}

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/ApolloUserDetailsService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/ApolloUserDetailsService.java
@@ -1,15 +1,21 @@
 package com.Teletubbies.Apollo.jwt.service;
 
+import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
 import com.Teletubbies.Apollo.jwt.repository.ApolloUserTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -21,14 +27,22 @@ public class ApolloUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String userLogin) throws UsernameNotFoundException {
         log.info("ApolloUserDetailsService 진입 성공");
         return apolloUserTokenRepository.findByUserLogin(userLogin)
-                .map(this::createUserDetail)
+                .map(apolloUserToken -> createUserDetail(userLogin, apolloUserToken))
                 .orElseThrow();
 
     }
-    public UserDetails createUserDetail(ApolloUserToken apolloUserToken){
-        return User.builder()
-                .username(apolloUserToken.getUsername())
-                .password(passwordEncoder.encode(apolloUserToken.getPassword()))
-                .build();
+    private User createUserDetail(String id, ApolloUserToken apolloUserToken){
+        log.info("createUser 진입 성공");
+        if (!apolloUserToken.isActivated())
+            throw new RuntimeException(id + "-> 활성화 되지 않은 사용자입니다.");
+
+        List<GrantedAuthority> grantedAuthorities = apolloUserToken.getAuthorities().stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+                .collect(Collectors.toList());
+        for (GrantedAuthority grantedAuthority : grantedAuthorities) {
+            System.out.println(grantedAuthority.getAuthority());
+        }
+        log.info("권한 정보 가져오기 성공");
+        return new User(apolloUserToken.getUserLogin(), passwordEncoder.encode(apolloUserToken.getUserId()), grantedAuthorities);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type: TRACE
+    org.springframework.security: DEBUG
 
 security:
   oauth:


### PR DESCRIPTION
- "authority" -> 권한의 목록을 담는 테이블
- "user_authority" -> 사용자 id와 권한 매핑한 테이블 (ApolloUserToken.Set<Authority> 다대다 매핑한거)
- ApolloUserToken의 UserDetail implement 제거, 제거 해도 Spring.Security.User 객체 생성이 가능
- ApolloUserDeatilsService에서 createUser 메서드에서 비밀번호는 인코딩 하는게 중요- > 그래야 비교가 가능 (인코딩한 값으로 비교해서)
- log 확인을 위해 yml 파일 logging level 추가 (Spring.Securiry = DEBUG)