### PR TITLE
Jwt authorization develop

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/controller/UserController.java
@@ -3,24 +3,32 @@ package com.Teletubbies.Apollo.auth.controller;
 import com.Teletubbies.Apollo.auth.domain.ApolloUser;
 import com.Teletubbies.Apollo.auth.dto.MemberInfoResponse;
 import com.Teletubbies.Apollo.auth.service.UserService;
+import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
+import com.Teletubbies.Apollo.jwt.service.AuthorityService;
 import com.Teletubbies.Apollo.jwt.service.JwtService;
+import com.Teletubbies.Apollo.jwt.service.UserAuthorityService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api")
 public class UserController {
     private final UserService userService;
+    private final AuthorityService authorityService;
     private final JwtService jwtService;
-    public UserController(UserService userService, JwtService jwtService){
-        this.userService = userService;
-        this.jwtService = jwtService;
-    }
     @PostMapping("/save/user")
     public String saveUser(@RequestBody MemberInfoResponse memberInfoResponse){
         ApolloUser savedUser = userService.saveUser(memberInfoResponse);
         log.info("Controller: 유저 저장 완료");
-        jwtService.toMakeTokenSaveObj(savedUser.getLogin(), savedUser.getId().toString());
+        ApolloUserToken apolloUserToken = jwtService.toMakeTokenSaveObj(savedUser.getLogin(), savedUser.getId().toString());
+        if (!authorityService.existAuthority(1L)){
+            log.info("권한 정보 저장 시도");
+            authorityService.saveAuthority("ROLE_USER");
+            log.info("권한 정보 저장 성공");
+        }
+        jwtService.saveUserAuthority(apolloUserToken, authorityService.findByName("ROLE_USER"));
         log.info("Token 기초 정보 저장 완료");
         return "ok";
     }

--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/ApolloUserToken.java
@@ -17,6 +17,7 @@ public class ApolloUserToken{
     @Column(nullable = false)
     private String userId;
     private boolean activated;
+    /*
 
     @ManyToMany
     @JoinTable(
@@ -24,6 +25,9 @@ public class ApolloUserToken{
             joinColumns = {@JoinColumn(name = "user_for_token_id", referencedColumnName = "user_for_token_id")},
             inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
     private Set<Authority> authorities;
+
+     */
+
     public ApolloUserToken(String userLogin, String userId){
         this.userLogin = userLogin;
         this.userId = userId;

--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/Authority.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/Authority.java
@@ -1,9 +1,6 @@
 package com.Teletubbies.Apollo.jwt.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +12,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "authorities")
 public class Authority {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "authority_id")
+    private Long id = null;
     @Column(name = "authority_name")
     private String authorityName;
+
+    public Authority(String authorityName) {
+        this.authorityName = authorityName;
+    }
 }

--- a/src/main/java/com/Teletubbies/Apollo/jwt/domain/UserAuthority.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/domain/UserAuthority.java
@@ -1,0 +1,26 @@
+package com.Teletubbies.Apollo.jwt.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "user_authority")
+@Getter
+public class UserAuthority {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne
+    @JoinColumn(name = "user_for_token_id")
+    private ApolloUserToken apolloUserToken;
+    @ManyToOne
+    @JoinColumn(name = "authority_id")
+    private Authority authority;
+
+    public UserAuthority(ApolloUserToken apolloUserToken, Authority authority) {
+        this.apolloUserToken = apolloUserToken;
+        this.authority = authority;
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/jwt/repository/AuthorityRepository.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/repository/AuthorityRepository.java
@@ -1,0 +1,8 @@
+package com.Teletubbies.Apollo.jwt.repository;
+
+import com.Teletubbies.Apollo.jwt.domain.Authority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+    Authority findByAuthorityName(String authorityName);
+}

--- a/src/main/java/com/Teletubbies/Apollo/jwt/repository/UserAuthorityRepository.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/repository/UserAuthorityRepository.java
@@ -1,0 +1,11 @@
+package com.Teletubbies.Apollo.jwt.repository;
+
+import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
+import com.Teletubbies.Apollo.jwt.domain.UserAuthority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserAuthorityRepository extends JpaRepository<UserAuthority, Long> {
+    List<UserAuthority> findAllByApolloUserToken(ApolloUserToken apolloUserToken);
+}

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/AuthorityService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/AuthorityService.java
@@ -1,0 +1,22 @@
+package com.Teletubbies.Apollo.jwt.service;
+
+import com.Teletubbies.Apollo.jwt.domain.Authority;
+import com.Teletubbies.Apollo.jwt.repository.AuthorityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+@Service
+@RequiredArgsConstructor
+public class AuthorityService {
+    private final AuthorityRepository authorityRepository;
+    @Transactional
+    public void saveAuthority(String auth){
+        authorityRepository.save(new Authority(auth));
+    }
+    public Authority findByName(String authorityName){
+        return authorityRepository.findByAuthorityName(authorityName);
+    }
+    public boolean existAuthority(Long id){
+        return authorityRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
@@ -60,4 +60,3 @@ public class JwtService {
         return tokenInfo;
     }
 }
-가

--- a/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
+++ b/src/main/java/com/Teletubbies/Apollo/jwt/service/JwtService.java
@@ -2,26 +2,35 @@ package com.Teletubbies.Apollo.jwt.service;
 
 import com.Teletubbies.Apollo.jwt.JwtTokenProvider;
 import com.Teletubbies.Apollo.jwt.domain.ApolloUserToken;
+import com.Teletubbies.Apollo.jwt.domain.Authority;
 import com.Teletubbies.Apollo.jwt.domain.Token;
+import com.Teletubbies.Apollo.jwt.domain.UserAuthority;
 import com.Teletubbies.Apollo.jwt.dto.TokenInfo;
 import com.Teletubbies.Apollo.jwt.repository.ApolloUserTokenRepository;
+import com.Teletubbies.Apollo.jwt.repository.UserAuthorityRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtService {
     private final ApolloUserTokenRepository apolloUserTokenRepository;
+    private final UserAuthorityRepository userAuthorityRepository;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenService tokenService;
-    public void toMakeTokenSaveObj(String userLogin, String userId){
-        apolloUserTokenRepository.save(new ApolloUserToken(userLogin, userId));
+    public ApolloUserToken toMakeTokenSaveObj(String userLogin, String userId){
+        return apolloUserTokenRepository.save(new ApolloUserToken(userLogin, userId));
+    }
+    @Transactional
+    public UserAuthority saveUserAuthority(ApolloUserToken userToken, Authority authority){
+        return userAuthorityRepository.save(new UserAuthority(userToken, authority));
     }
     public TokenInfo login(String userLogin, String userId){
         // 1. Login ID/PW 를 기반으로 Authentication 객체 생성
@@ -51,3 +60,4 @@ public class JwtService {
         return tokenInfo;
     }
 }
+가


### PR DESCRIPTION
- 인증받은 객체인 ApolloUserToken에 권한 목록이 있었는데 이를 제거하고 UserAuthority라는 테이블을 만듬
- 또한 사용자의 권한이 아닌 전체 권한의 목록을 담는 Authoritry라는 객체(테이블을 만듬)
- 이렇게 해서 다대다 매핑을 빼고 일대다, 다대일 매핑으로 전환
- 엔티티가 추가로 생긴만큼 레포지토리나 서비스 로직 추가
- ** 유저가 권한을 갖는게 아니라 따로 엔티티로 관리하기 때문에 CustomUserDetailService (ApolloUserDetailsService) 로직에 인증 받는 방시에 변화가 있음 (기존: apolloUser.getAuthorities -> 변경: authority.getAuthority().getAuthorityName())) **코드 보면 이해할거임
- 추가적으로 SQL문으로 DB값을 변화시키면 JPA에서 알아먹지를 못함 -> UserController에 이를 해결하기 위한 로직 추가