### PR TITLE
Mapping post tag develop

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
@@ -5,6 +5,12 @@ import com.Teletubbies.Apollo.auth.service.UserService;
 import com.Teletubbies.Apollo.board.domain.Post;
 import com.Teletubbies.Apollo.board.dto.SavePostRequest;
 import com.Teletubbies.Apollo.board.service.PostService;
+import com.Teletubbies.Apollo.board.domain.PostWithTag;
+import com.Teletubbies.Apollo.board.domain.Tag;
+import com.Teletubbies.Apollo.board.dto.SavePostRequest;
+import com.Teletubbies.Apollo.board.service.PostService;
+import com.Teletubbies.Apollo.board.service.PostWithTagService;
+import com.Teletubbies.Apollo.board.service.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,19 +18,33 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class PostController {
     private final PostService postService;
+    private final TagService tagService;
+    private final PostWithTagService postWithTagService;
     private final UserService userService;
     @PostMapping("/register/board")
-    public Long registerPost(@RequestBody SavePostRequest request){
+    public List<Tag> registerPost(@RequestBody SavePostRequest request){
         log.info("컨트롤러 단 진입 완료");
         ApolloUser findUser = userService.getUserById(request.getUserId());
+
         Post post = postService.savePost(findUser, request);
         log.info("게시글 저장 완료");
-        return post.getId();
+
+        List<Tag> tags = tagService.saveTag(request.getTagNames());
+        log.info("태그 저장 완료");
+
+        for (Tag tag : tags) {
+            postWithTagService.savePostWithTag(post, tag);
+        }
+        log.info("태그와 게시물 연관 저장 완료");
+
+        return tags;
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/domain/Post.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/domain/Post.java
@@ -23,11 +23,11 @@ public class Post {
     private Date createAt;
     private Date updateAt;
 
-    public Post(ApolloUser apolloUser, String title, String content, Date createAt) {
+    public Post(ApolloUser apolloUser, String title, String content) {
         this.apolloUser = apolloUser;
         this.title = title;
         this.content = content;
-        this.createAt = createAt;
-        this.updateAt = createAt;
+        this.createAt = new Date();
+        this.updateAt = new Date();
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/domain/PostWithTag.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/domain/PostWithTag.java
@@ -1,0 +1,27 @@
+package com.Teletubbies.Apollo.board.domain;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Table(name = "post_tag_association")
+public class PostWithTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_tag_association_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "post_id")
+    private Post post;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+    public PostWithTag(Post post, Tag tag) {
+        this.post = post;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/domain/Tag.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/domain/Tag.java
@@ -1,19 +1,21 @@
 package com.Teletubbies.Apollo.board.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Tag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
     private Long id;
-    @ManyToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
     @Column(name = "tag_name")
     private String name;
+
+    public Tag(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/SavePostRequest.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/SavePostRequest.java
@@ -2,9 +2,12 @@ package com.Teletubbies.Apollo.board.dto;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class SavePostRequest {
     private Long userId;
     private String title;
     private String content;
+    private List<String> tagNames;
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/repository/PostWithTagRepository.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/repository/PostWithTagRepository.java
@@ -1,0 +1,11 @@
+package com.Teletubbies.Apollo.board.repository;
+
+import com.Teletubbies.Apollo.board.domain.PostWithTag;
+import com.Teletubbies.Apollo.board.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostWithTagRepository extends JpaRepository<PostWithTag, Long> {
+    List<PostWithTag> findAllByTag(Tag tag);
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/repository/TagRepository.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package com.Teletubbies.Apollo.board.repository;
+
+import com.Teletubbies.Apollo.board.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    boolean existsByName(String name);
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
@@ -17,6 +17,6 @@ public class PostService {
     private final PostRepository postRepository;
     public Post savePost(ApolloUser apolloUser, SavePostRequest savePostRequest){
         log.info("서비스 단 진입 완료");
-        return postRepository.save(new Post(apolloUser, savePostRequest.getTitle(), savePostRequest.getContent(), new Date()));
+        return postRepository.save(new Post(apolloUser, savePostRequest.getTitle(), savePostRequest.getContent()));
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/service/PostWithTagService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/PostWithTagService.java
@@ -1,0 +1,19 @@
+package com.Teletubbies.Apollo.board.service;
+
+import com.Teletubbies.Apollo.board.domain.Post;
+import com.Teletubbies.Apollo.board.domain.PostWithTag;
+import com.Teletubbies.Apollo.board.domain.Tag;
+import com.Teletubbies.Apollo.board.repository.PostWithTagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostWithTagService {
+    private final PostWithTagRepository postWithTagRepository;
+    public void savePostWithTag(Post post, Tag tag){
+        postWithTagRepository.save(new PostWithTag(post, tag));
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/service/TagService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/TagService.java
@@ -1,0 +1,34 @@
+package com.Teletubbies.Apollo.board.service;
+
+import com.Teletubbies.Apollo.board.domain.Post;
+import com.Teletubbies.Apollo.board.domain.PostWithTag;
+import com.Teletubbies.Apollo.board.domain.Tag;
+import com.Teletubbies.Apollo.board.repository.PostWithTagRepository;
+import com.Teletubbies.Apollo.board.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TagService {
+    private final TagRepository tagRepository;
+    public List<Tag> saveTag(List<String> tagNames){
+        List<Tag> tags = tagNames.stream()
+                .map(tagName -> {
+                    if (!tagRepository.existsByName(tagName)) {
+                        return tagRepository.save(new Tag(tagName));
+                    } else {
+                        return tagRepository.findByName(tagName)
+                                .orElseThrow(() -> new IllegalArgumentException("해당 태그에 대한 정보가 없습니다."));
+                    }
+                })
+                .collect(Collectors.toList());
+        return tags;
+    }
+}


### PR DESCRIPTION
- tag랑 post 매핑 성공
- tag와 post는 서로에 대한 정보를 갖고 있지 않음
- 서로 연관된 정보는 무조건 PostWithTag(post_tag_association)을 통해서 접근이 가능함
- 현재 저장로직만 구현한 상태 삭제 같은 추가 기능 할 예정
- 구현 로직은 그냥 단순함 코드 보면 한 번에 이해 쌉가능