### PR TITLE
Change JSON data field that return to frontend

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
@@ -9,10 +9,7 @@ import com.Teletubbies.Apollo.board.dto.comment.response.CommentInPostResponse;
 import com.Teletubbies.Apollo.board.dto.post.request.DeletePostRequest;
 import com.Teletubbies.Apollo.board.dto.post.request.SavePostRequest;
 import com.Teletubbies.Apollo.board.dto.post.request.UpdatePostRequest;
-import com.Teletubbies.Apollo.board.dto.post.response.FindPostResponse;
-import com.Teletubbies.Apollo.board.dto.post.response.PostDetailResponse;
-import com.Teletubbies.Apollo.board.dto.post.response.SavePostResponse;
-import com.Teletubbies.Apollo.board.dto.post.response.UpdatePostResponse;
+import com.Teletubbies.Apollo.board.dto.post.response.*;
 import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
 import com.Teletubbies.Apollo.board.service.CommentService;
 import com.Teletubbies.Apollo.board.service.PostService;
@@ -52,8 +49,8 @@ public class PostController {
         return new SavePostResponse(post.getId(), findUser.getId());
     }
     @GetMapping("/board")
-    public List<FindPostResponse> findAllPosts(){
-        return postService.findAllPosts();
+    public StartBoard findAllPosts(){
+        return new StartBoard(postService.findAllPosts(), tagService.findAllTag());
     }
     @GetMapping("/tag")
     public List<ConvertTag> findAllTags() {return tagService.findAllTag();}
@@ -67,7 +64,7 @@ public class PostController {
                 .toList();
         log.info("게시글의 태그 조회 완료, 태그 dto 변환 완료");
 
-        FindPostResponse postResponse = new FindPostResponse(findPost.getApolloUser().getId(), findPost.getId(), findPost.getTitle(), findPost.getContent());
+        OriginPostResponse postResponse = new OriginPostResponse(findPost.getApolloUser().getId(), findPost.getId(), findPost.getTitle(), findPost.getContent(), tagOfPost, findPost.getCreateAt());
         log.info("게시글 dto 변환 완료");
 
         List<Comment> findComments = commentService.findAllCommentByPost(findPost);

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/FindPostResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/FindPostResponse.java
@@ -1,18 +1,24 @@
 package com.Teletubbies.Apollo.board.dto.post.response;
 
+import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
 import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
 
 @Data
 public class FindPostResponse {
     private Long userId;
     private Long postId;
     private String title;
-    private String content;
+    private List<ConvertTag> tags;
+    private Date createAt;
 
-    public FindPostResponse(Long userId, Long postId, String title, String content) {
+    public FindPostResponse(Long userId, Long postId, String title, List<ConvertTag> tags, Date createAt) {
         this.userId = userId;
         this.postId = postId;
         this.title = title;
-        this.content = content;
+        this.tags = tags;
+        this.createAt = createAt;
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/OriginPostResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/OriginPostResponse.java
@@ -1,0 +1,26 @@
+package com.Teletubbies.Apollo.board.dto.post.response;
+
+import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+public class OriginPostResponse {
+    private Long userId;
+    private Long postId;
+    private String title;
+    private String content;
+    private List<ConvertTag> tags;
+    private Date createAt;
+
+    public OriginPostResponse(Long userId, Long postId, String title, String content, List<ConvertTag> tags, Date createAt) {
+        this.userId = userId;
+        this.postId = postId;
+        this.title = title;
+        this.content = content;
+        this.tags = tags;
+        this.createAt = createAt;
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/PostDetailResponse.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/PostDetailResponse.java
@@ -9,11 +9,11 @@ import java.util.List;
 
 @Data
 public class PostDetailResponse {
-    private FindPostResponse post;
+    private OriginPostResponse post;
     private List<CommentInPostResponse> comments;
     private List<ConvertTag> tags;
 
-    public PostDetailResponse(FindPostResponse post, List<CommentInPostResponse> comments, List<ConvertTag> tags) {
+    public PostDetailResponse(OriginPostResponse post, List<CommentInPostResponse> comments, List<ConvertTag> tags) {
         this.post = post;
         this.comments = comments;
         this.tags = tags;

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/StartBoard.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/post/response/StartBoard.java
@@ -1,0 +1,16 @@
+package com.Teletubbies.Apollo.board.dto.post.response;
+
+import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
+import lombok.Data;
+
+import java.util.List;
+@Data
+public class StartBoard {
+    List<FindPostResponse> posts;
+    List<ConvertTag> tags;
+
+    public StartBoard(List<FindPostResponse> posts, List<ConvertTag> tags) {
+        this.posts = posts;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/Teletubbies/Apollo/board/dto/tag/ConvertTag.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/dto/tag/ConvertTag.java
@@ -1,5 +1,6 @@
 package com.Teletubbies.Apollo.board.dto.tag;
 
+import com.Teletubbies.Apollo.board.domain.Tag;
 import lombok.Data;
 
 @Data
@@ -10,5 +11,9 @@ public class ConvertTag {
     public ConvertTag(Long tagId, String tagName) {
         this.tagId = tagId;
         this.tagName = tagName;
+    }
+    public ConvertTag(Tag tag){
+        this.tagId = tag.getId();
+        this.tagName = tag.getName();
     }
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
@@ -7,6 +7,7 @@ import com.Teletubbies.Apollo.board.domain.Tag;
 import com.Teletubbies.Apollo.board.dto.post.request.DeletePostRequest;
 import com.Teletubbies.Apollo.board.dto.post.request.SavePostRequest;
 import com.Teletubbies.Apollo.board.dto.post.response.FindPostResponse;
+import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
 import com.Teletubbies.Apollo.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,8 @@ public class PostService {
                         findPost.getApolloUser().getId(),
                         findPost.getId(),
                         findPost.getTitle(),
-                        findPost.getContent()))
+                        tagService.findAllTag(),
+                        findPost.getCreateAt()))
                 .toList();
 
     }
@@ -49,22 +51,28 @@ public class PostService {
         List<Post> findPosts = postRepository.findByTitleContainingIgnoreCase(title);
         return findPosts.stream()
                 .map(findPost -> new FindPostResponse(
-                        findPost.getId(),
                         findPost.getApolloUser().getId(),
+                        findPost.getId(),
                         findPost.getTitle(),
-                        findPost.getContent()))
-                .collect(Collectors.toList());
+                        postWithTagService.findPostWithTagByPost(findPost).stream()
+                                .map(postWithTag -> new ConvertTag(postWithTag.getTag()))
+                                .toList(),
+                        findPost.getCreateAt()))
+                .toList();
 
     }
     public List<FindPostResponse> findSimilarPostByTitleOrContent(String searchString){
         List<Post> findPosts = postRepository.findByContentContainingIgnoreCaseOrTitleContainingIgnoreCase(searchString, searchString);
         return findPosts.stream()
                 .map(findPost -> new FindPostResponse(
-                        findPost.getId(),
                         findPost.getApolloUser().getId(),
+                        findPost.getId(),
                         findPost.getTitle(),
-                        findPost.getContent()))
-                .collect(Collectors.toList());
+                        postWithTagService.findPostWithTagByPost(findPost).stream()
+                                .map(postWithTag -> new ConvertTag(postWithTag.getTag()))
+                                .toList(),
+                        findPost.getCreateAt()))
+                .toList();
     }
     //update
     @Transactional


### PR DESCRIPTION
- 기존 게시글 로직들은 임시적으로 나 혼자 생각하고 만든 로직들
- 프론트 엔드에서 게시글 작업을 시작한 이후로 맞추는 과정에 있음
- 프론트 엔드에서 게시글 초기화면 시 넘기는 정보는 유저 아이디, 게시글 아이디, 제목, 해당 태그들 , 생성시간으로 맞춰달라고 함
- 기존에 내가 작성한 로직이랑 맞지 않아서 수정
- 게시글 초기화면 로딩 -> 존재하는 태그에 대한 정보, 게시글에 대한 정보(위에 언급한 내용)을 보내줌
- 게시글 클릭(해당 게시글에 대한 정보만 로딩) -> 유저아이디, 게시글의 태그들, 제목, 내용, 댓글을 보내줌
- 이렇게 수정 완료
- 추후에 해야할 부분 -> paging 기능 추가해야함, 생성시간 가까운 순 정렬 해야함