### PR TITLE
Fix: 게시판 초기 정보 에러 발견 후 수정

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
@@ -42,7 +42,9 @@ public class PostService {
                         findPost.getApolloUser().getId(),
                         findPost.getId(),
                         findPost.getTitle(),
-                        tagService.findAllTag(),
+                        postWithTagService.findPostWithTagByPost(findPost).stream()
+                                .map(postWithTag -> new ConvertTag(postWithTag.getTag()))
+                                .toList(),
                         findPost.getCreateAt()))
                 .toList();
 


### PR DESCRIPTION
- 게시판 초기 정보 제공 시 태그에 대한 에러 발견
- 태그 조회 방식 변경 후 완료