### PR TITLE
Fix: 게시글 초기화면 제공 정보 paging 적용

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/controller/PostController.java
@@ -18,6 +18,8 @@ import com.Teletubbies.Apollo.board.service.PostWithTagService;
 import com.Teletubbies.Apollo.board.service.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,8 +51,9 @@ public class PostController {
         return new SavePostResponse(post.getId(), findUser.getId());
     }
     @GetMapping("/board")
-    public StartBoard findAllPosts(){
-        return new StartBoard(postService.findAllPosts(), tagService.findAllTag());
+    public StartBoard findAllPosts(@RequestParam int pageNum){
+        PageRequest pageRequest = PageRequest.of(pageNum - 1, 3, Sort.by("createAt").descending());
+        return new StartBoard(postService.findAllPosts(pageRequest), tagService.findAllTag());
     }
     @GetMapping("/tag")
     public List<ConvertTag> findAllTags() {return tagService.findAllTag();}

--- a/src/main/java/com/Teletubbies/Apollo/board/repository/PostRepository.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/repository/PostRepository.java
@@ -1,7 +1,8 @@
 package com.Teletubbies.Apollo.board.repository;
 
 import com.Teletubbies.Apollo.board.domain.Post;
-import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findById(Long id);
-    List<Post> findAll();
+    Page<Post> findAll(Pageable pageable);
     List<Post> findByContentContainingIgnoreCaseOrTitleContainingIgnoreCase(String title, String content);
     List<Post> findByTitleContainingIgnoreCase(String title);
 }

--- a/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/service/PostService.java
@@ -11,6 +11,7 @@ import com.Teletubbies.Apollo.board.dto.tag.ConvertTag;
 import com.Teletubbies.Apollo.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,8 +38,8 @@ public class PostService {
         return postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글 아이디입니다."));
     }
-    public List<FindPostResponse> findAllPosts(){
-        return postRepository.findAll(Sort.by(Sort.Direction.DESC, "createAt")).stream()
+    public List<FindPostResponse> findAllPosts(PageRequest pageRequest){
+        return postRepository.findAll(pageRequest).stream()
                 .map(findPost -> new FindPostResponse(
                         findPost.getApolloUser().getId(),
                         findPost.getId(),


### PR DESCRIPTION
- 현재 문제 게시글 조회, 수정 시 경로가 애매함 ("/api/board/{pageNum}", "/api/board/{postId}")
- 그래서 url query로 변경하는 게 좋을 듯 ex. "/api/board?pageNum=1"
- 페이지 정보를 넘겨주면 현재는 3개만 전달하도록 설정 -> 숫자만 바꾸면 되니까 추후 변경 쉬움
- 일단 게시판 초기 화면 정보 paging 성공, 추후에 paging 필요한 곳에 추가 예정