### PR TITLE
Refactor: 양방향 연관관계 추가로 로직 최적화 적용

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/board/domain/Post.java
+++ b/src/main/java/com/Teletubbies/Apollo/board/domain/Post.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -21,8 +22,8 @@ public class Post {
     private String title;
     @Column(columnDefinition = "LONGTEXT")
     private String content;
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
-    private List<Comment> comments;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
     private Date createAt;
     private Date updateAt;
 


### PR DESCRIPTION
- post <-> comment 양방향 연관관계 적용으로 
- post에 속한 comment를 굳이 서비스 단을 통해서 조회할 필요가 사라짐
- 이를 적용했음