### PR TITLE
Fix: JPA 영속성 관련 mapping 해제

### DIFF
--- a/src/main/java/com/Teletubbies/Apollo/auth/domain/ApolloUser.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/domain/ApolloUser.java
@@ -30,7 +30,7 @@ public class ApolloUser {
     private List<Repo> repos;
     @OneToOne(mappedBy = "apolloUser", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Credential credential;
-    @OneToMany(mappedBy = "apolloUser", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "apolloUser", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<ApolloDeployService> services;
 
     public ApolloUser(SaveUserRequest saveUserRequest) {

--- a/src/main/java/com/Teletubbies/Apollo/auth/domain/Repo.java
+++ b/src/main/java/com/Teletubbies/Apollo/auth/domain/Repo.java
@@ -19,8 +19,6 @@ public class Repo {
     private String repoName;
     private String repoUrl;
     private String ownerLogin;
-    @OneToOne(mappedBy = "repo", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private ApolloDeployService service;
 
     public Repo(RepoInfoResponse response) {
         this.id = response.getId();

--- a/src/main/java/com/Teletubbies/Apollo/core/exception/CustomErrorCode.java
+++ b/src/main/java/com/Teletubbies/Apollo/core/exception/CustomErrorCode.java
@@ -17,6 +17,7 @@ public enum CustomErrorCode {
     DUPLICATED_REPO_ERROR("409", "이미 존재하는 레포지토리입니다"),
     API_NOT_FOUND_ERROR("4300", "존재하지 않는 API입니다"),
     CREDENTIAL_NOT_FOUND_ERROR("4301", "존재하지 않는 크리덴셜입니다"),
+    NOT_FOUND_SERVICE_ERROR("4302", "존재하지 않는 서비스입니다"),
 
     RUNTIME_ERROR("9902", "알 수 없는 예외가 발생했습니다"),
     APOLLO_ERROR("9901", "처리하지 못한 예외입니다");

--- a/src/main/java/com/Teletubbies/Apollo/deploy/controller/AWSCloudFormationController.java
+++ b/src/main/java/com/Teletubbies/Apollo/deploy/controller/AWSCloudFormationController.java
@@ -2,6 +2,7 @@ package com.Teletubbies.Apollo.deploy.controller;
 
 import com.Teletubbies.Apollo.auth.service.UserService;
 import com.Teletubbies.Apollo.deploy.dto.request.DeleteClientDeployRequest;
+import com.Teletubbies.Apollo.deploy.dto.request.DeleteServerDeployRequest;
 import com.Teletubbies.Apollo.deploy.dto.request.PostClientDeployRequest;
 import com.Teletubbies.Apollo.deploy.dto.request.PostServerDeployRequest;
 import com.Teletubbies.Apollo.deploy.dto.response.*;
@@ -24,7 +25,6 @@ import java.util.List;
 public class AWSCloudFormationController {
     private final AWSCloudFormationClientService awsCloudformationClientService;
     private final AWSCloudFormationServerService awsCloudFormationServerService;
-    private final UserService userService;
     private final AWSCloudFormationService awsCloudFormationService;
 
     @Operation(summary = "Client stack 생성", description = "CloudFormation을 이용하여 Client stack을 생성한다.")
@@ -42,8 +42,7 @@ public class AWSCloudFormationController {
             @PathVariable Long userId,
             @RequestBody DeleteClientDeployRequest request
     ) {
-        String repoName = request.getRepoName();
-        awsCloudformationClientService.deleteClientStack(userId, repoName);
+        awsCloudformationClientService.deleteClientStack(userId, request);
         DeleteClientDeployResponse response = new DeleteClientDeployResponse();
         response.setContent("Client stack is deleted successfully");
         return response;
@@ -63,10 +62,9 @@ public class AWSCloudFormationController {
     @DeleteMapping("/cloudformation/{userId}/server")
     public DeleteServerDeployResponse deleteServerStack(
             @PathVariable Long userId,
-            @RequestBody DeleteClientDeployRequest request
+            @RequestBody DeleteServerDeployRequest request
     ) {
-        String repoName = request.getRepoName();
-        awsCloudFormationServerService.deleteServerStack(userId, repoName);
+        awsCloudFormationServerService.deleteServerStack(userId, request);
         DeleteServerDeployResponse response = new DeleteServerDeployResponse();
         response.setContent("Server stack is deleted successfully");
         return response;

--- a/src/main/java/com/Teletubbies/Apollo/deploy/domain/ApolloDeployService.java
+++ b/src/main/java/com/Teletubbies/Apollo/deploy/domain/ApolloDeployService.java
@@ -23,10 +23,6 @@ public class ApolloDeployService {
     @JoinColumn(name = "user_id")
     private ApolloUser apolloUser;
 
-    @OneToOne
-    @JoinColumn(name = "repository_id")
-    private Repo repo;
-
     @Column(name = "stack_name")
     private String stackName;
     @Column(name = "stack_type")
@@ -52,9 +48,9 @@ public class ApolloDeployService {
         updatedAt = new Date();
     }
 
-    public ApolloDeployService(ApolloUser user, Repo repo, String stackName, String endpoint, String stackType) {
+    public ApolloDeployService(ApolloUser user, String stackName, String endpoint, String stackType) {
         this.apolloUser = user;
-        this.repo = repo;
+//        this.repo = repo;
         this.stackName = stackName;
         this.endpoint = endpoint;
         this.stackType = stackType;

--- a/src/main/java/com/Teletubbies/Apollo/deploy/dto/request/DeleteClientDeployRequest.java
+++ b/src/main/java/com/Teletubbies/Apollo/deploy/dto/request/DeleteClientDeployRequest.java
@@ -5,6 +5,6 @@ import lombok.Data;
 
 @Data
 public class DeleteClientDeployRequest {
-    @JsonProperty("repoName")
-    private String repoName;
+    @JsonProperty("serviceId")
+    private Long serviceId;
 }

--- a/src/main/java/com/Teletubbies/Apollo/deploy/dto/request/DeleteServerDeployRequest.java
+++ b/src/main/java/com/Teletubbies/Apollo/deploy/dto/request/DeleteServerDeployRequest.java
@@ -5,6 +5,6 @@ import lombok.Data;
 
 @Data
 public class DeleteServerDeployRequest {
-    @JsonProperty("repoName")
-    private String repoName;
+    @JsonProperty("serviceId")
+    private Long serviceId;
 }

--- a/src/main/java/com/Teletubbies/Apollo/deploy/service/AWSCloudFormationClientService.java
+++ b/src/main/java/com/Teletubbies/Apollo/deploy/service/AWSCloudFormationClientService.java
@@ -9,10 +9,13 @@ import com.Teletubbies.Apollo.credential.exception.CredentialException;
 import com.Teletubbies.Apollo.credential.repository.CredentialRepository;
 import com.Teletubbies.Apollo.deploy.component.AwsClientComponent;
 import com.Teletubbies.Apollo.deploy.domain.ApolloDeployService;
+import com.Teletubbies.Apollo.deploy.dto.request.DeleteClientDeployRequest;
 import com.Teletubbies.Apollo.deploy.dto.request.PostClientDeployRequest;
 import com.Teletubbies.Apollo.deploy.dto.response.PostClientDeployResponse;
 import com.Teletubbies.Apollo.deploy.exception.DeploymentException;
 import com.Teletubbies.Apollo.deploy.repository.AwsServiceRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +24,7 @@ import software.amazon.awssdk.services.cloudformation.model.*;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
-import static com.Teletubbies.Apollo.core.exception.CustomErrorCode.CREDENTIAL_NOT_FOUND_ERROR;
-import static com.Teletubbies.Apollo.core.exception.CustomErrorCode.NOT_FOUND_REPO_ERROR;
+import static com.Teletubbies.Apollo.core.exception.CustomErrorCode.*;
 
 @Service
 @Slf4j
@@ -32,6 +34,9 @@ public class AWSCloudFormationClientService {
     private final CredentialRepository credentialRepository;
     private final AwsServiceRepository awsServiceRepository;
     private final UserService userService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     public AWSCloudFormationClientService(AwsClientComponent awsClientComponent, RepoRepository repoRepository, CredentialRepository credentialRepository, AwsServiceRepository awsServiceRepository, UserService userService) {
         this.awsClientComponent = awsClientComponent;
@@ -47,10 +52,10 @@ public class AWSCloudFormationClientService {
         String repoName = request.getRepoName();
         String EndPoint = createClientStack(cfClient, repoName);
         ApolloUser user = userService.getUserById(userId);
-        Repo repo = repoRepository.findByRepoName(repoName)
-                .orElseThrow(() -> new DeploymentException(NOT_FOUND_REPO_ERROR, "해당 레포가 존재하지 않습니다."));
+//        Repo repo = repoRepository.findByRepoName(repoName)
+//                .orElseThrow(() -> new DeploymentException(NOT_FOUND_REPO_ERROR, "해당 레포가 존재하지 않습니다."));
         ApolloDeployService apolloDeployService =
-                new ApolloDeployService(user, repo, repoName, EndPoint, "client");
+                new ApolloDeployService(user, repoName, EndPoint, "client");
         awsServiceRepository.save(apolloDeployService);
         return new PostClientDeployResponse(repoName, "client", EndPoint);
     }
@@ -94,17 +99,13 @@ public class AWSCloudFormationClientService {
     }
 
     @Transactional
-    public void deleteClientStack(Long userId, String stackName) {
+    public void deleteClientStack(Long userId, DeleteClientDeployRequest request) {
         CloudFormationClient cfClient = awsClientComponent.createCFClient(userId);
         S3Client s3Client = awsClientComponent.createS3Client(userId);
-        ApolloUser user = userService.getUserById(userId);
+        ApolloDeployService service = awsServiceRepository.findById(request.getServiceId())
+                .orElseThrow(() -> new DeploymentException(NOT_FOUND_SERVICE_ERROR, "해당 서비스가 존재하지 않습니다."));
+        String stackName = service.getStackName();
         String bucketName = getBucketName(cfClient, stackName);
-
-        ApolloDeployService apolloDeployService = awsServiceRepository.findByApolloUserAndStackName(user, stackName);
-        if (apolloDeployService != null) {
-            awsServiceRepository.delete(apolloDeployService);
-            log.info("서비스 삭제 완료: " + apolloDeployService);
-        }
 
         if (bucketName != null) {
             deleteS3Bucket(s3Client, bucketName);
@@ -112,14 +113,19 @@ public class AWSCloudFormationClientService {
         } else {
             log.info("버킷이 존재하지 않습니다.");
         }
+        if (!service.getApolloUser().getId().equals(userId))
+            throw new IllegalArgumentException("서비스 작성자와 삭제자가 일치하지 않습니다.");
+        awsServiceRepository.delete(service);
+        log.info("Delete service: " + stackName + " successfully");
     }
+
 
     private void deleteS3Bucket(S3Client s3Client, String bucketName) {
         try {
             emptyS3Bucket(s3Client, bucketName);
             DeleteBucketRequest deleteBucketRequest = DeleteBucketRequest.builder().bucket(bucketName).build();
             s3Client.deleteBucket(deleteBucketRequest);
-            log.info("Delete bucket: " + bucketName + " successfully");
+            log.info("다음 버킷을 삭제했습니다.: " + bucketName);
         } catch (Exception e) {
             log.info("버킷 삭제중에 에러가 발생했습니다.: " + e.getMessage());
         }


### PR DESCRIPTION
- JPA 영속성 중 Cascade시 단일 엔티티에 완전히 종속적일때만 사용 가능한 조건 위반
- service 도메인 중 repo 도메인 종속 해제
- 테스트 결과 성공